### PR TITLE
recieve server group id in machine provider config

### DIFF
--- a/pkg/cloudprovider/provider/openstack/helper.go
+++ b/pkg/cloudprovider/provider/openstack/helper.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gophercloud/gophercloud"
 	goopenstack "github.com/gophercloud/gophercloud/openstack"
 	osavailabilityzones "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
+	osservergroups "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
 	osflavors "github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 	osimages "github.com/gophercloud/gophercloud/openstack/compute/v2/images"
 	osregions "github.com/gophercloud/gophercloud/openstack/identity/v3/regions"
@@ -88,6 +89,14 @@ func getAvailabilityZones(client *gophercloud.ProviderClient, region string) ([]
 		return nil, err
 	}
 	return osavailabilityzones.ExtractAvailabilityZones(allPages)
+}
+
+func getServerGroup(client *gophercloud.ProviderClient, id, region string) (*osservergroups.ServerGroup, error) {
+	computeClient, err := goopenstack.NewComputeV2(client, gophercloud.EndpointOpts{Region: region})
+	if err != nil {
+		return nil, err
+	}
+	return osservergroups.Get(computeClient, id).Extract()
 }
 
 func getAvailabilityZone(client *gophercloud.ProviderClient, region, name string) (*osavailabilityzones.AvailabilityZone, error) {

--- a/pkg/cloudprovider/provider/openstack/types/types.go
+++ b/pkg/cloudprovider/provider/openstack/types/types.go
@@ -42,6 +42,8 @@ type RawConfig struct {
 	TrustDevicePath       providerconfigtypes.ConfigVarBool     `json:"trustDevicePath"`
 	RootDiskSizeGB        *int                                  `json:"rootDiskSizeGB"`
 	NodeVolumeAttachLimit *uint                                 `json:"nodeVolumeAttachLimit"`
+
+	ServerGroupID providerconfigtypes.ConfigVarString `json:"serverGroupID"`
 	// This tag is related to server metadata, not compute server's tag
 	Tags map[string]string `json:"tags,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Controller receives and uses Openstack server group id / Now when creating machine-controller we are able to specify server group for it.

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
configurable server group id for openstack machinedeployments
```
