### PR TITLE
k8s-4730 Fix hanging reboot on auto update.

### DIFF
--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -395,6 +395,7 @@ storage:
           PasswordAuthentication no
           ChallengeResponseAuthentication no
 
+{{- if not .FlatcarConfig.DisableAutoUpdate }}
     - path: "/etc/polkit-1/rules.d/60-noreboot_norestart.rule"
       filesystem: root
       mode: 0644
@@ -410,6 +411,7 @@ storage:
                   }
               }
           });
+{{- end }}
 
     - path: /etc/docker/daemon.json
       filesystem: root

--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -395,6 +395,22 @@ storage:
           PasswordAuthentication no
           ChallengeResponseAuthentication no
 
+    - path: "/etc/polkit-1/rules.d/60-noreboot_norestart.rule"
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          polkit.addRule(function(action, subject) {
+              if (action.id == "org.freedesktop.login1.reboot" ||
+                  action.id == "org.freedesktop.login1.reboot-multiple-sessions") {
+                  if (subject.user == "core") {
+                      return polkit.Result.YES;
+                  } else {
+                      return polkit.Result.AUTH_ADMIN;
+                  }
+              }
+          });
+
     - path: /etc/docker/daemon.json
       filesystem: root
       mode: 0644


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the polkit permission required for the user to reboot the machine. The user runs flatcar-update-controller and needs permissions to reboot the machine when flatcar-update-controller receives a signal for the OS to update.

**Special notes for your reviewer**:
The PR is not created at upstream because support for flatcar does not exist in https://github.com/kubermatic/machine-controller `master` branch.

**Optional Release Note**:

```release-note
Fix hanging reboots after auto updates on flatcar machines.
```