### PR TITLE
Add image ID to custom createOpts

### DIFF
--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -488,6 +488,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.Pr
 	createOpts = &osservers.CreateOpts{
 		Name:             machine.Spec.Name,
 		FlavorRef:        flavor.ID,
+		ImageRef:         image.ID,
 		UserData:         []byte(userdata),
 		SecurityGroups:   securityGroups,
 		AvailabilityZone: c.AvailabilityZone,


### PR DESCRIPTION
Syseleven/machine-controller has diverged from default serverOpts.
Upstream the image id will only be set when not booted from volume
because it could fail otherwise.

This commit will only fix the immediate issue where no machines can be
created. It could still be that booting from volumes doesn't work for
some cloudproviders.

I would suggest to try and be closer to upstream so this doesn't happen
that easy.
