### PR TITLE
k8s-4730 Fix polkit rules filename for flatcar reboot.

### DIFF
--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -396,7 +396,7 @@ storage:
           ChallengeResponseAuthentication no
 
 {{- if not .FlatcarConfig.DisableAutoUpdate }}
-    - path: "/etc/polkit-1/rules.d/60-noreboot_norestart.rule"
+    - path: "/etc/polkit-1/rules.d/60-noreboot_norestart.rules"
       filesystem: root
       mode: 0644
       contents:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix tha nema of polkit rules file from `/etc/polkit-1/rules.d/60-noreboot_norestart.rule` to `/etc/polkit-1/rules.d/60-noreboot_norestart.rules` to fix reboot allowed by `core` user.

**Optional Release Note**:u
```release-note
Fix flatcar reboot rule for `core` user.
```
