### PR TITLE
Bugfix/kubelet stopped posting node status

### DIFF
--- a/pkg/userdata/coreos/provider.go
+++ b/pkg/userdata/coreos/provider.go
@@ -154,6 +154,14 @@ const userDataTemplate = `passwd:
 {{- if .ProviderSpec.Network }}
 networkd:
   units:
+{{- /* SysEleven block start */ }}
+    - name: kubelet-restart.service
+      enabled: true
+      contents:
+        inline: |
+{{ kubeletRestartOnNotReadyScript | indent 10 }}
+{{- /* SysEleven block end */ }}
+
     - name: static-nic.network
       contents: |
         [Match]
@@ -303,6 +311,15 @@ systemd:
 
 storage:
   files:
+{{- /* SysEleven block start */}}
+	- path: /opt/restart-kubelet.sh
+	  filesystem: root
+	  permissions: 0755
+	  contents:
+	    inline: |
+{{ kubeletRestartOnNotReadyScript | indent 10 }}
+{{- /* SysEleven block end */}}
+
 {{- if .HTTPProxy }}
     - path: /etc/environment
       filesystem: root

--- a/pkg/userdata/coreos/provider.go
+++ b/pkg/userdata/coreos/provider.go
@@ -154,13 +154,12 @@ const userDataTemplate = `passwd:
 {{- if .ProviderSpec.Network }}
 networkd:
   units:
-{{- /* SysEleven block start */ }}
+{{- /* SysEleven block start */}}
     - name: kubelet-restart.service
       enabled: true
       contents:
-        inline: |
 {{ kubeletRestartOnNotReadyScript | indent 10 }}
-{{- /* SysEleven block end */ }}
+{{- /* SysEleven block end */}}
 
     - name: static-nic.network
       contents: |
@@ -312,11 +311,11 @@ systemd:
 storage:
   files:
 {{- /* SysEleven block start */}}
-	- path: /opt/restart-kubelet.sh
-	  filesystem: root
-	  permissions: 0755
-	  contents:
-	    inline: |
+    - path: /opt/kubelet-restart.sh
+      filesystem: root
+      mode: 0755
+      contents:
+        inline: |
 {{ kubeletRestartOnNotReadyScript | indent 10 }}
 {{- /* SysEleven block end */}}
 

--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -149,13 +149,12 @@ networkd:
 
 systemd:
   units:
-{{- /* SysEleven block start */ }}
+{{- /* SysEleven block start */}}
     - name: kubelet-restart.service
       enabled: true
-      contents:
-        inline: |
-{{ kubeletRestartOnNotReadyScript | indent 10 }}
-{{- /* SysEleven block end */ }}
+      contents: |
+{{ kubeletRestartOnNotReadySystemdUnit | indent 10 }}
+{{- /* SysEleven block end */}}
 
 {{- if .FlatcarConfig.DisableUpdateEngine }}
     - name: update-engine.service
@@ -291,14 +290,14 @@ systemd:
 
 storage:
   files:
-{{- /* SysEleven block start */ }}
-	- path: /opt/restart-kubelet.sh
-	  filesystem: root
-	  permissions: 0755
-	  contents:
-	    inline: |
+{{- /* SysEleven block start */}}
+    - path: /opt/kubelet-restart.sh
+      filesystem: root
+      mode: 0755
+      contents:
+        inline: |
 {{ kubeletRestartOnNotReadyScript | indent 10 }}
-{{- /* SysEleven block end */ }}
+{{- /* SysEleven block end */}}
 
     - path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
       filesystem: root

--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -149,6 +149,14 @@ networkd:
 
 systemd:
   units:
+{{- /* SysEleven block start */ }}
+    - name: kubelet-restart.service
+      enabled: true
+      contents:
+        inline: |
+{{ kubeletRestartOnNotReadyScript | indent 10 }}
+{{- /* SysEleven block end */ }}
+
 {{- if .FlatcarConfig.DisableUpdateEngine }}
     - name: update-engine.service
       mask: true
@@ -283,14 +291,14 @@ systemd:
 
 storage:
   files:
-{{- if .HTTPProxy }}
-    - path: /etc/environment
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: |
-{{ proxyEnvironment .HTTPProxy .NoProxy | indent 10 }}
-{{- end }}
+{{- /* SysEleven block start */ }}
+	- path: /opt/restart-kubelet.sh
+	  filesystem: root
+	  permissions: 0755
+	  contents:
+	    inline: |
+{{ kubeletRestartOnNotReadyScript | indent 10 }}
+{{- /* SysEleven block end */ }}
 
     - path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
       filesystem: root

--- a/pkg/userdata/helper/kubelet.go
+++ b/pkg/userdata/helper/kubelet.go
@@ -243,3 +243,37 @@ ExecStart=/opt/bin/health-monitor.sh container-runtime
 [Install]
 WantedBy=multi-user.target`
 }
+
+// KubeletRestartOnNotReadyScript script to check kubelet stopped posting node status every 10 minutes
+// Syseleven method
+func KubeletRestartOnNotReadyScript() string {
+	return `#!/bin/bash
+
+while true; do
+	output=$(journalctl -u kubelet -n 1 | grep "use of closed network connection")
+	if [[ $? != 0 ]]; then
+	  echo "Error not found in logs"
+	elif [[ $output ]]; then
+	  echo "Restart kubelet"
+	  systemctl restart kubelet
+	fi
+
+	# Runs every 10 minutes
+	sleep 600
+done`
+}
+
+// KubeletRestartOnNotReadySystemdUnit restart kubelet on error
+// Syseleven method
+func KubeletRestartOnNotReadySystemdUnit() string {
+	return `[Unit]
+Description=Restarts kubelet on use of closed network connection error
+Requires=kubelet.service
+After=kubelet.service
+
+[Service]
+ExecStart=/opt/kubelet-restart.sh
+
+[Install]
+WantedBy=multi-user.target`
+}

--- a/pkg/userdata/helper/template_functions.go
+++ b/pkg/userdata/helper/template_functions.go
@@ -41,6 +41,10 @@ func TxtFuncMap() template.FuncMap {
 	funcMap["dockerConfig"] = DockerConfig
 	funcMap["proxyEnvironment"] = ProxyEnvironment
 
+	// Syseleven Block: Workaround for kubelet stopped posting node status
+	funcMap["kubeletRestartOnNotReadyScript"] = KubeletRestartOnNotReadyScript
+	funcMap["kubeletRestartOnNotReadySystemdUnit"] = KubeletRestartOnNotReadySystemdUnit
+
 	return funcMap
 }
 

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -130,6 +130,18 @@ ssh_authorized_keys:
 {{- end }}
 
 write_files:
+{{- /* SysEleven block start */}}
+- path: "/opt/restart-kubelet.sh"
+  permissions: "0755"
+  content: |
+{{ kubeletRestartOnNotReadyScript | indent 4 }}
+
+- path: "/etc/systemd/system/kubelet-restart.service"
+  permissions: "0644"
+  content: |
+{{ kubeletRestartOnNotReadySystemdUnit | indent 4 }}
+{{- /* SysEleven block end */}}
+
 {{- if .HTTPProxy }}
 - path: "/etc/environment"
   content: |
@@ -221,6 +233,9 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+{{- /* SysEleven block start */}}
+	systemctl enable --now --no-block kubelet-restart.service
+{{- /* SysEleven block end */}}
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -40,7 +40,7 @@ type Provider struct{}
 func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 	tmpl, err := template.New("user-data").Funcs(userdatahelper.TxtFuncMap()).Parse(userDataTemplate)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse user-data template: %v", err)
+		return "", fmt.Errorf("FAILED TO PARSE USER-DATA TEMPLATE: %V", err)
 	}
 
 	kubeletVersion, err := semver.NewVersion(req.MachineSpec.Versions.Kubelet)

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -131,6 +131,18 @@ ssh_authorized_keys:
 {{- end }}
 
 write_files:
+{{- /* SysEleven block start */}}
+- path: "/opt/restart-kubelet.sh"
+  permissions: "0755"
+  content: |
+{{ kubeletRestartOnNotReadyScript | indent 4 }}
+
+- path: "/etc/systemd/system/kubelet-restart.service"
+  permissions: "0644"
+  content: |
+{{ kubeletRestartOnNotReadySystemdUnit | indent 4 }}
+{{- /* SysEleven block end */}}
+
 {{- if .HTTPProxy }}
 - path: "/etc/environment"
   content: |
@@ -300,6 +312,9 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+{{- /* SysEleven block start */}}
+	systemctl enable --now --no-block kubelet-restart.service
+{{- /* SysEleven block end */}}
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -132,7 +132,7 @@ ssh_authorized_keys:
 
 write_files:
 {{- /* SysEleven block start */}}
-- path: "/opt/restart-kubelet.sh"
+- path: "/opt/kubelet-restart.sh"
   permissions: "0755"
   content: |
 {{ kubeletRestartOnNotReadyScript | indent 4 }}
@@ -313,7 +313,7 @@ write_files:
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
 {{- /* SysEleven block start */}}
-	systemctl enable --now --no-block kubelet-restart.service
+    systemctl enable --now --no-block kubelet-restart.service
 {{- /* SysEleven block end */}}
 
 - path: "/opt/bin/supervise.sh"


### PR DESCRIPTION
**What this PR does / why we need it**:

Sometimes the kubelet suddenly starts to hang and the kubelet needs to be restarted, or even the node if there is no ssh access.
This pr adds a script to cloud init to check the kubelet logs periodically and restarts the kubelet if needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
automatically restart broken kubelets
```
