### PR TITLE
Increase default ready timeout

### DIFF
--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -185,7 +185,7 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 			c.InstanceReadyCheckTimeout = 10 * time.Second
 		}
 	} else {
-		c.InstanceReadyCheckTimeout = 10 * time.Second
+		c.InstanceReadyCheckTimeout = 100 * time.Second
 	}
 
 	// We ignore errors here because the OS domain is only required when using Identity API V3


### PR DESCRIPTION
**What this PR does / why we need it**: Because default 10seconds are not enough

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Increase default ready timeout form 10s to 100s.
```
