### PR TITLE
Add enable-ingress-hostname option to cloudconfig

### DIFF
--- a/pkg/cloudprovider/provider/openstack/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/openstack/types/cloudconfig.go
@@ -49,6 +49,9 @@ lb-provider = {{ .LoadBalancer.LBProvider | iniEscape }}
 {{- if .LoadBalancer.UseOctavia }}
 use-octavia = {{ .LoadBalancer.UseOctavia | boolPtr }}
 {{- end }}
+{{- if .LoadBalancer.EnableIngressHostname }}
+enable-ingress-hostname = {{ .LoadBalancer.EnableIngressHostname }}
+{{- end }}
 
 {{- if .LoadBalancer.CreateMonitor }}
 create-monitor = {{ .LoadBalancer.CreateMonitor }}
@@ -73,17 +76,18 @@ node-volume-attach-limit = {{ .BlockStorage.NodeVolumeAttachLimit }}
 )
 
 type LoadBalancerOpts struct {
-	LBVersion            string       `gcfg:"lb-version"`
-	SubnetID             string       `gcfg:"subnet-id"`
-	FloatingNetworkID    string       `gcfg:"floating-network-id"`
-	LBMethod             string       `gcfg:"lb-method"`
-	LBProvider           string       `gcfg:"lb-provider"`
-	CreateMonitor        bool         `gcfg:"create-monitor"`
-	MonitorDelay         ini.Duration `gcfg:"monitor-delay"`
-	MonitorTimeout       ini.Duration `gcfg:"monitor-timeout"`
-	MonitorMaxRetries    uint         `gcfg:"monitor-max-retries"`
-	ManageSecurityGroups bool         `gcfg:"manage-security-groups"`
-	UseOctavia           *bool        `gcfg:"use-octavia"`
+	LBVersion             string       `gcfg:"lb-version"`
+	SubnetID              string       `gcfg:"subnet-id"`
+	FloatingNetworkID     string       `gcfg:"floating-network-id"`
+	LBMethod              string       `gcfg:"lb-method"`
+	LBProvider            string       `gcfg:"lb-provider"`
+	CreateMonitor         bool         `gcfg:"create-monitor"`
+	MonitorDelay          ini.Duration `gcfg:"monitor-delay"`
+	MonitorTimeout        ini.Duration `gcfg:"monitor-timeout"`
+	MonitorMaxRetries     uint         `gcfg:"monitor-max-retries"`
+	ManageSecurityGroups  bool         `gcfg:"manage-security-groups"`
+	UseOctavia            *bool        `gcfg:"use-octavia"`
+	EnableIngressHostname bool         `gcfg:"enable-ingress-hostname"`
 }
 
 type BlockStorageOpts struct {


### PR DESCRIPTION
enable-ingress-hostname option will add a suffix to ingress ips to make
kubernetes believe that these are hostnames and will stop to add
iptables bypasses.

This is a workaround to be able to query a loadbalancer from within the
cluster when using proxy protocol.

This option will likely be removed in the future once a solution by
kubernetes has been released.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
