### PR TITLE
K8s-8540 Check for all 404 error types for openstack get

### DIFF
--- a/pkg/cloudprovider/provider/openstack/helper.go
+++ b/pkg/cloudprovider/provider/openstack/helper.go
@@ -428,3 +428,17 @@ func getDefaultSubnet(netClient *gophercloud.ServiceClient, network *osnetworks.
 	}
 	return &subnets[0].ID, nil
 }
+
+func isErrNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch err.(type) {
+	case gophercloud.ErrDefault404:
+		return true
+	case gophercloud.Err404er:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -830,7 +830,7 @@ func (p *provider) Cleanup(ctx context.Context, machine *clusterv1alpha1.Machine
 		return false, osErrorToTerminalError(err, "failed to get compute client")
 	}
 
-	if err := osservers.Delete(computeClient, instance.ID()).ExtractErr(); err != nil && !errors.Is(err, &gophercloud.ErrDefault404{}) {
+	if err := osservers.Delete(computeClient, instance.ID()).ExtractErr(); err != nil && !isErrNotFound(err) {
 		return false, osErrorToTerminalError(err, "failed to delete instance")
 	}
 
@@ -1105,7 +1105,7 @@ func (p *provider) cleanupFloatingIP(machine *clusterv1alpha1.Machine, updater c
 	if err != nil {
 		return fmt.Errorf("failed to create the networkv2 client for region %s: %w", c.Region, err)
 	}
-	if err := osfloatingips.Delete(netClient, floatingIPID).ExtractErr(); err != nil && !errors.Is(err, &gophercloud.ErrDefault404{}) {
+	if err := osfloatingips.Delete(netClient, floatingIPID).ExtractErr(); err != nil && !isErrNotFound(err) {
 		return fmt.Errorf("failed to delete floating ip %s: %w", floatingIPID, err)
 	}
 	if err := updater(machine, func(m *clusterv1alpha1.Machine) {


### PR DESCRIPTION
**What this PR does / why we need it**:

test errors on get requests during deletion on all types of gophercloud 404 errors.
Usually the error that gets returned is a default404 err but depending on the response from openstack other 404 errs can also be returned.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
