### PR TITLE
K8s-9372: Add modification for custom policy

### DIFF
--- a/pkg/apis/cluster/v1alpha1/machineset_types.go
+++ b/pkg/apis/cluster/v1alpha1/machineset_types.go
@@ -100,10 +100,9 @@ const (
 	// It then prioritizes the oldest Machines for deletion based on the Machine's CreationTimestamp.
 	OldestMachineSetDeletePolicy MachineSetDeletePolicy = "Oldest"
 
-	// CustomMachineSetDeletePolicy prioritizes both Machines that have the annotation
-	// "cluster.k8s.io/delete-machine=yes" and Machines that are unhealthy
-	// (Status.ErrorReason or Status.ErrorMessage are set to a non-empty value).
-	// If then prioritizes the machine with Status different from Ready.
+	// CustomMachineSetDeletePolicy prioritizes deletion of newer machines or the ones
+	// that are with a different status than "Ready". If then prioritizes the deletion
+	// of machines that have errors or deletion annotations added.
 	CustomMachineSetDeletePolicy MachineSetDeletePolicy = "Custom"
 )
 

--- a/pkg/apis/cluster/v1alpha1/machineset_types.go
+++ b/pkg/apis/cluster/v1alpha1/machineset_types.go
@@ -78,7 +78,7 @@ type MachineSetSpec struct {
 }
 
 // MachineSetDeletePolicy defines how priority is assigned to nodes to delete when
-// downscaling a MachineSet. Defaults to "Custom".
+// downscaling a MachineSet. Defaults to "Default".
 type MachineSetDeletePolicy string
 
 const (

--- a/pkg/apis/cluster/v1alpha1/machineset_types.go
+++ b/pkg/apis/cluster/v1alpha1/machineset_types.go
@@ -100,10 +100,10 @@ const (
 	// It then prioritizes the oldest Machines for deletion based on the Machine's CreationTimestamp.
 	OldestMachineSetDeletePolicy MachineSetDeletePolicy = "Oldest"
 
-	// CustomMachineSetDeletePolicy prioritizes deletion of newer machines or the ones
-	// that are with a different status than "Ready". If then prioritizes the deletion
-	// of machines that have errors or deletion annotations added.
-	CustomMachineSetDeletePolicy MachineSetDeletePolicy = "Custom"
+	// DefaultDeletePolicy prioritizes deletion of newer machines or the ones
+	// referenced to a K8s node (relation between machine (OpenStack) - node (Kubernetes)). 
+	// If then prioritizes the deletion of machines that have errors or deletion annotations added.
+	DefaultDeletePolicy MachineSetDeletePolicy = "Default"
 )
 
 /// [MachineSetSpec] // doxygen marker
@@ -208,9 +208,9 @@ func (m *MachineSet) Default() {
 	}
 
 	if m.Spec.DeletePolicy == "" {
-		customPolicy := string(CustomMachineSetDeletePolicy)
-		log.Printf("Defaulting to %s\n", customPolicy)
-		m.Spec.DeletePolicy = customPolicy
+		defaultPolicy := string(DefaultDeletePolicy)
+		log.Printf("Defaulting to %s\n", defaultPolicy)
+		m.Spec.DeletePolicy = defaultPolicy
 	}
 }
 

--- a/pkg/apis/cluster/v1alpha1/machineset_types.go
+++ b/pkg/apis/cluster/v1alpha1/machineset_types.go
@@ -61,7 +61,7 @@ type MachineSetSpec struct {
 	MinReadySeconds int32 `json:"minReadySeconds,omitempty"`
 
 	// DeletePolicy defines the policy used to identify nodes to delete when downscaling.
-	// Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+	// Defaults to "Custom".  Valid values are "Random, "Newest", "Oldest"
 	// +kubebuilder:validation:Enum=Random,Newest,Oldest
 	DeletePolicy string `json:"deletePolicy,omitempty"`
 
@@ -78,7 +78,7 @@ type MachineSetSpec struct {
 }
 
 // MachineSetDeletePolicy defines how priority is assigned to nodes to delete when
-// downscaling a MachineSet. Defaults to "Random".
+// downscaling a MachineSet. Defaults to "Custom".
 type MachineSetDeletePolicy string
 
 const (

--- a/pkg/apis/cluster/v1alpha1/machineset_types.go
+++ b/pkg/apis/cluster/v1alpha1/machineset_types.go
@@ -99,6 +99,12 @@ const (
 	// (Status.ErrorReason or Status.ErrorMessage are set to a non-empty value).
 	// It then prioritizes the oldest Machines for deletion based on the Machine's CreationTimestamp.
 	OldestMachineSetDeletePolicy MachineSetDeletePolicy = "Oldest"
+
+	// CustomMachineSetDeletePolicy prioritizes both Machines that have the annotation
+	// "cluster.k8s.io/delete-machine=yes" and Machines that are unhealthy
+	// (Status.ErrorReason or Status.ErrorMessage are set to a non-empty value).
+	// If then prioritizes the machine with Status different from Ready.
+	CustomMachineSetDeletePolicy MachineSetDeletePolicy = "Custom"
 )
 
 /// [MachineSetSpec] // doxygen marker

--- a/pkg/apis/cluster/v1alpha1/machineset_types.go
+++ b/pkg/apis/cluster/v1alpha1/machineset_types.go
@@ -61,8 +61,8 @@ type MachineSetSpec struct {
 	MinReadySeconds int32 `json:"minReadySeconds,omitempty"`
 
 	// DeletePolicy defines the policy used to identify nodes to delete when downscaling.
-	// Defaults to "Custom".  Valid values are "Random, "Newest", "Oldest"
-	// +kubebuilder:validation:Enum=Random,Newest,Oldest
+	// Defaults to "Default".  Valid values are "Default", "Random, "Newest", "Oldest"
+	// +kubebuilder:validation:Enum=Default,Random,Newest,Oldest
 	DeletePolicy string `json:"deletePolicy,omitempty"`
 
 	// Selector is a label query over machines that should match the replica count.

--- a/pkg/apis/cluster/v1alpha1/machineset_types.go
+++ b/pkg/apis/cluster/v1alpha1/machineset_types.go
@@ -209,9 +209,9 @@ func (m *MachineSet) Default() {
 	}
 
 	if m.Spec.DeletePolicy == "" {
-		randomPolicy := string(RandomMachineSetDeletePolicy)
-		log.Printf("Defaulting to %s\n", randomPolicy)
-		m.Spec.DeletePolicy = randomPolicy
+		customPolicy := string(CustomMachineSetDeletePolicy)
+		log.Printf("Defaulting to %s\n", customPolicy)
+		m.Spec.DeletePolicy = customPolicy
 	}
 }
 

--- a/pkg/controller/machineset/delete_policy.go
+++ b/pkg/controller/machineset/delete_policy.go
@@ -81,7 +81,7 @@ func defaultDeletePolicy(machine *v1alpha1.Machine) deletePriority {
 		return mustDelete
 	}
 
-	if machine.Status.NodeRef == nil{
+	if machine.Status.NodeRef == nil {
 		return mustDelete
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is required by K8s-9372 to add a new DeletePolicy that allows us to remove machines that are in a different status than "Ready" before checking the rest of the cases/situations, like newer or older machines.

**Which issue(s) this PR fixes**:
Fixes #K8s-9372
